### PR TITLE
35 configure pacman color parallel downloads custom repo support

### DIFF
--- a/configs/airootfs/etc/profile.d/pit-aliases.sh
+++ b/configs/airootfs/etc/profile.d/pit-aliases.sh
@@ -1,8 +1,16 @@
+#!/bin/bash
 # Ferrari OS package manager aliases
-alias update='pit -Syu'
-alias install='pit -S'
-alias remove='pit -R'
-alias search='pit -Ss'
-alias clean='pit -Sc'
-alias info='pit -Si'
-alias packages='pit -Q'
+# System update
+alias pit-update='pit -Syu'
+# Package installation
+alias pit-install='pit -S'
+# Package removal
+alias pit-remove='pit -R'
+# Package search
+alias pit-search='pit -Ss'
+# Clean package cache
+alias pit-clean='pit -Sc'
+# Package information
+alias pit-info='pit -Si'
+# List installed packages
+alias pit-list='pit -Q'

--- a/configs/airootfs/etc/profile.d/pit-aliases.sh
+++ b/configs/airootfs/etc/profile.d/pit-aliases.sh
@@ -1,0 +1,8 @@
+# Ferrari OS package manager aliases
+alias update='pit -Syu'
+alias install='pit -S'
+alias remove='pit -R'
+alias search='pit -Ss'
+alias clean='pit -Sc'
+alias info='pit -Si'
+alias packages='pit -Q'

--- a/configs/airootfs/usr/local/bin/pit
+++ b/configs/airootfs/usr/local/bin/pit
@@ -34,12 +34,21 @@ show_header() {
 # Show appropriate message based on operation
 show_message() {
     local op=${1#-}
+
+    # Try exact match first
+    if [[ -n "${MESSAGES[$op]}" ]]; then
+        echo "${YELLOW}${MESSAGES[$op]}${NC}"
+        return
+    fi
+
+    # Fall back to partial match if needed
     for key in "${!MESSAGES[@]}"; do
-        if [[ $op == *"$key"* ]]; then
+        if [[ $op == "$key"* ]]; then
             echo "${YELLOW}${MESSAGES[$key]}${NC}"
             return
         fi
     done
+
     echo "${YELLOW}[PIT] Executing operation...${NC}"
 }
 

--- a/configs/airootfs/usr/local/bin/pit
+++ b/configs/airootfs/usr/local/bin/pit
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+# Check for TTY and set colors accordingly
+if [ -t 1 ] && command -v tput >/dev/null; then
+    RED="$(tput bold)$(tput setaf 1)"
+    GREEN="$(tput bold)$(tput setaf 2)"
+    YELLOW="$(tput bold)$(tput setaf 3)"
+    NC="$(tput sgr0)"
+else
+    RED=""
+    GREEN=""
+    YELLOW=""
+    NC=""
+fi
+
+# TTY-friendly messages without emoji
+declare -A MESSAGES=(
+    ["Syu"]="[PIT STOP] Starting full system upgrade..."
+    ["S"]="[INSTALL] Installing new components..."
+    ["R"]="[REMOVE] Removing components..."
+    ["Ss"]="[SEARCH] Searching package catalog..."
+    ["Q"]="[LIST] Checking installed components..."
+    ["Sc"]="[CLEAN] Cleaning package cache..."
+    ["Si"]="[INFO] Getting package details..."
+)
+
+# TTY-friendly header using simple ASCII
+show_header() {
+    echo "${RED}+--------------------------------+"
+    echo "|     Ferrari Package Manager      |"
+    echo "+--------------------------------+${NC}"
+}
+
+# Show appropriate message based on operation
+show_message() {
+    local op=${1#-}
+    for key in "${!MESSAGES[@]}"; do
+        if [[ $op == *"$key"* ]]; then
+            echo "${YELLOW}${MESSAGES[$key]}${NC}"
+            return
+        fi
+    done
+    echo "${YELLOW}[PIT] Executing operation...${NC}"
+}
+
+# Show usage if no arguments provided
+if [ $# -eq 0 ]; then
+    show_header
+    echo "${GREEN}Usage: pit <operation> [options] [targets]${NC}"
+    echo ""
+    echo "Operations:"
+    echo "  -Syu         Full system upgrade"
+    echo "  -S package   Install a package"
+    echo "  -R package   Remove a package"
+    echo "  -Ss name     Search for packages"
+    echo "  -Sc         Clean package cache"
+    echo "  -Si package  Show package info"
+    echo "  -Q          List installed packages"
+    exit 1
+fi
+
+show_header
+show_message "$1"
+
+# Execute pacman with all arguments
+exec pacman "$@"

--- a/configs/airootfs/usr/share/bash-completion/completions/pit
+++ b/configs/airootfs/usr/share/bash-completion/completions/pit
@@ -1,0 +1,2 @@
+source /usr/share/bash-completion/completions/pacman
+complete -F _pacman pit

--- a/configs/pacman.conf
+++ b/configs/pacman.conf
@@ -39,6 +39,8 @@ ParallelDownloads = 10
 #DownloadUser = alpm
 #DisableSandbox
 
+UseFerrariWrapper = true
+
 # By default, pacman accepts packages signed by keys that its local keyring
 # trusts (see pacman-key and its man page), as well as unsigned packages.
 SigLevel    = Required DatabaseOptional

--- a/configs/pacman.conf
+++ b/configs/pacman.conf
@@ -30,12 +30,12 @@ Architecture = auto
 
 # Misc options
 #UseSyslog
-#Color
-#NoProgressBar
+Color
+ILoveCandy
 # We cannot check disk space from within a chroot environment
-#CheckSpace
-#VerbosePkgLists
-ParallelDownloads = 5
+CheckSpace
+VerbosePkgLists
+ParallelDownloads = 10
 #DownloadUser = alpm
 #DisableSandbox
 

--- a/scripts/build_iso.sh
+++ b/scripts/build_iso.sh
@@ -1,5 +1,5 @@
-+#!/usr/bin/env bash
-+set -euo pipefail
+#!/usr/bin/env bash
+set -euo pipefail
 # Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -18,6 +18,27 @@ OUT_DIR="$ROOT_DIR/out"
 # Create package directory if it doesn't exist
 mkdir -p "$PACKAGE_DIR"
 
+# Create required directories
+mkdir -p configs/airootfs/usr/local/bin
+mkdir -p configs/airootfs/usr/share/bash-completion/completions
+mkdir -p configs/airootfs/etc/profile.d
+
+# Create Ferrari OS aliases file
+cat > "$CONFIG_DIR/airootfs/etc/profile.d/pit-aliases.sh" << 'EOL'
+# Ferrari OS package manager aliases
+alias update='pit -Syu'
+alias install='pit -S'
+alias remove='pit -R'
+alias search='pit -Ss'
+alias clean='pit -Sc'
+alias info='pit -Si'
+alias packages='pit -Q'
+EOL
+
+# Set permissions
+chmod +x configs/airootfs/usr/local/bin/pit
+chmod 644 configs/airootfs/usr/share/bash-completion/completions/pit
+chmod 644 configs/airootfs/etc/profile.d/pit-aliases.sh
 # Check for required package files
 REQUIRED_FILES=("base.txt" "desktop.txt" "development.txt" "multimedia.txt")
 MISSING_FILES=()
@@ -51,6 +72,22 @@ done
 if [ -d "$WORK_DIR" ]; then
     echo -e "${BLUE}Cleaning previous build...${NC}"
     rm -rf "$WORK_DIR"
+fi
+
+if [ ! -f "$CONFIG_DIR/airootfs/usr/local/bin/pit" ]; then
+    echo -e "${RED}Error: pit wrapper not created successfully${NC}"
+    exit 1
+fi
+
+if [ ! -f "$CONFIG_DIR/airootfs/usr/share/bash-completion/completions/pit" ]; then
+    echo -e "${RED}Error: pit completion not created successfully${NC}"
+    exit 1
+fi
+
+# Verify permissions
+if [ ! -x "$CONFIG_DIR/airootfs/usr/local/bin/pit" ]; then
+    echo -e "${RED}Error: pit wrapper is not executable${NC}"
+    exit 1
 fi
 
 # Build ISO


### PR DESCRIPTION
Created Pit , the package manager for Ferrari-OS (wrapper for Pacman)

updated pacman.conf

```shell
Color
ILoveCandy
CheckSpace
VerbosePkgLists
ParallelDownloads = 10
UseFerrariWrapper = true


```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced the Ferrari Package Manager (`pit`) as a user-friendly wrapper for package management tasks.
	- Added convenient command aliases for common package operations.
	- Enabled bash auto-completion for the `pit` command, matching the behavior of `pacman`.

- **Improvements**
	- Enhanced package manager output with color, animation, and more detailed package lists.
	- Increased the number of parallel package downloads for faster updates.

- **Chores**
	- Improved build process to ensure required files and permissions are correctly set before ISO creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->